### PR TITLE
Fix emitter cleanup

### DIFF
--- a/src/views/MealView.vue
+++ b/src/views/MealView.vue
@@ -40,7 +40,7 @@
 </template>
 
 <script setup>
-import { computed, inject, ref, watchEffect } from 'vue'
+import { computed, inject, ref, watchEffect, onUnmounted } from 'vue'
 import { useRouter } from 'vue-router'
 
 const emitter = inject('emitter')
@@ -97,6 +97,11 @@ function filterSearch(search) {
 }
 
 emitter.on('filterSearch', filterSearch)
+
+onUnmounted(() => {
+  emitter.off('switchLayout', switchLayout)
+  emitter.off('filterSearch', filterSearch)
+})
 </script>
 
 <style scoped>


### PR DESCRIPTION
## Summary
- clean up event listeners when MealView unmounts

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*

------
https://chatgpt.com/codex/tasks/task_e_687ce4fc10c4832a88e5fb54bc95870c