### PR TITLE
Fix DeleteModal ID and references

### DIFF
--- a/src/components/cart-page/DeleteModal.vue
+++ b/src/components/cart-page/DeleteModal.vue
@@ -1,5 +1,5 @@
 <template>
-  <div id="deleteModel" ref="modal" class="modal fade" tabindex="-1">
+  <div id="deleteModal" ref="modal" class="modal fade" tabindex="-1">
     <div class="modal-dialog modal-dialog-centered modal-sm-unresponsive">
       <div class="modal-content">
         <div class="modal-body text-center" style="padding: 1.5rem 1.5rem 1rem">

--- a/src/components/cart-page/EditWindow.vue
+++ b/src/components/cart-page/EditWindow.vue
@@ -143,7 +143,7 @@
             <button
               type="button"
               class="btn btn-outline-danger me-auto px-3"
-              data-bs-target="#deleteModel"
+              data-bs-target="#deleteModal"
               data-bs-toggle="modal"
               @click="askToDelete"
             >

--- a/src/views/CartPage.vue
+++ b/src/views/CartPage.vue
@@ -235,7 +235,7 @@ const deleteModal = ref(null)
 onBeforeRouteLeave(() => {
   if (
     document.getElementById('editModal').classList.contains('show') ||
-    document.getElementById('deleteModel').classList.contains('show')
+    document.getElementById('deleteModal').classList.contains('show')
   ) {
     editModal.value.modalInstance.hide()
     deleteModal.value.modalInstance.hide()


### PR DESCRIPTION
## Summary
- rename DeleteModal DOM id to `deleteModal`
- update modal references in EditWindow and CartPage

## Testing
- `npm run lint` *(fails: npm not found)*
- `npm run dev` *(fails: npm not found)*

------
https://chatgpt.com/codex/tasks/task_e_687ce6d68b18832a9f7d4f4c85c435a8