### PR TITLE
Fix empty order history crash

### DIFF
--- a/src/views/OrderHistoryPage.vue
+++ b/src/views/OrderHistoryPage.vue
@@ -71,7 +71,8 @@ const orderHistory = inject('orderHistory')
 const paymentStatus = inject('paymentStatus')
 
 const currentDate = computed(() => {
-  return new Date(orderHistory.value[0].dateTime).toLocaleDateString()
+  const first = orderHistory.value[0]
+  return first ? new Date(first.dateTime).toLocaleDateString() : ''
 })
 
 // 總金額


### PR DESCRIPTION
## Summary
- avoid reading `orderHistory[0]` when the array is empty

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*
- `npm run format`

------
https://chatgpt.com/codex/tasks/task_e_687ce6d92b7c832a93bf8f680bebd436