### PR TITLE
Add vitest setup and cart tests

### DIFF
--- a/package.json
+++ b/package.json
@@ -8,7 +8,8 @@
     "build": "vite build",
     "preview": "vite preview",
     "lint": "eslint . --fix",
-    "format": "prettier --write src/"
+    "format": "prettier --write src/",
+    "test": "vitest"
   },
   "dependencies": {
     "@popperjs/core": "^2.11.8",
@@ -27,6 +28,10 @@
     "prettier": "3.5.1",
     "sass": "^1.85.0",
     "vite": "^6.1.0",
-    "vite-plugin-vue-devtools": "^7.7.2"
+    "vite-plugin-vue-devtools": "^7.7.2",
+    "vitest": "^1.5.0",
+    "@vue/test-utils": "^2.4.2",
+    "@testing-library/vue": "^9.4.2",
+    "jsdom": "^24.0.0"
   }
 }

--- a/tests/cart.test.js
+++ b/tests/cart.test.js
@@ -1,0 +1,69 @@
+import { describe, it, expect } from 'vitest'
+import { mount } from '@vue/test-utils'
+import { ref } from 'vue'
+import ProductWindow from '../src/components/menu-page/ProductWindow.vue'
+import EditWindow from '../src/components/cart-page/EditWindow.vue'
+
+// helper function to create a meal item
+const baseMeal = { strMeal: 'Test Meal', price: 100 }
+
+describe('cart operations', () => {
+  it('adds an item to the cart', () => {
+    const cartData = ref([])
+    const wrapper = mount(ProductWindow, {
+      props: { mealPropped: baseMeal },
+      global: { provide: { cartData, diningFinished: ref(false) } },
+    })
+
+    wrapper.vm.userSettings.count = 1
+    wrapper.vm.addToCart()
+
+    expect(cartData.value.length).toBe(1)
+    expect(cartData.value[0].mealObject.strMeal).toBe('Test Meal')
+  })
+
+  it('edits an item in the cart', () => {
+    const cartItem = {
+      mealObject: baseMeal,
+      setMenuObject: { setMenuId: 'No', setMenuPrice: 0 },
+      spicyObject: { value: 'no' },
+      extraObject: { value: false, price: 0, name: '' },
+      notes: '',
+      count: 1,
+      subtotal: 100,
+      dateTime: 1,
+    }
+    const cartData = ref([cartItem])
+    const wrapper = mount(EditWindow, {
+      props: { cartItemPropped: { mealItem: baseMeal, options: { setMenuRadio: 'No', spicy: 'no', extra: false, notes: '', count: 1 }, dateTime: 1 } },
+      global: { provide: { cartData, emitter: { on: () => {}, off: () => {}, emit: () => {} } } },
+    })
+
+    wrapper.vm.userEditing.count = 2
+    wrapper.vm.finishEditing()
+
+    expect(cartData.value[0].count).toBe(2)
+  })
+
+  it('deletes an item from the cart', () => {
+    const cartItem = {
+      mealObject: baseMeal,
+      setMenuObject: { setMenuId: 'No', setMenuPrice: 0 },
+      spicyObject: { value: 'no' },
+      extraObject: { value: false, price: 0, name: '' },
+      notes: '',
+      count: 1,
+      subtotal: 100,
+      dateTime: 1,
+    }
+    const cartData = ref([cartItem])
+    const wrapper = mount(EditWindow, {
+      props: { cartItemPropped: { mealItem: baseMeal, options: cartItem, dateTime: 1 } },
+      global: { provide: { cartData, emitter: { on: () => {}, off: () => {}, emit: () => {} } } },
+    })
+
+    wrapper.vm.deleteCartItem()
+
+    expect(cartData.value.length).toBe(0)
+  })
+})

--- a/vitest.config.js
+++ b/vitest.config.js
@@ -1,0 +1,9 @@
+import { defineConfig } from 'vitest/config'
+import vue from '@vitejs/plugin-vue'
+
+export default defineConfig({
+  plugins: [vue()],
+  test: {
+    environment: 'jsdom'
+  }
+})


### PR DESCRIPTION
## Summary
- add Vitest config and testing dependencies
- create tests for cart add, edit, and delete logic
- expose `npm test` script

## Testing
- `npm test` *(fails: vitest not found)*

------
https://chatgpt.com/codex/tasks/task_e_687ce6dea0cc832ab17597bd0fd7c338